### PR TITLE
feat: clean unused lambda layers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ jspm_packages
 
 # packaged.yml
 packaged.yml
+packaged.yaml
 
 # Coverage directory used by tools like istanbul
 coverage

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![CircleCI](https://circleci.com/gh/lumigo/SAR-Lambda-Janitor.svg?style=svg)](https://circleci.com/gh/lumigo/SAR-Lambda-Janitor)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 
-Cron job for deleting old, unused versions of your Function.
+Cron job for deleting old, unused versions of your functions and layers.
 
 This [post](https://lumigo.io/blog/a-serverless-application-to-clean-up-old-deployment-packages/) explains the problem and why we created this app.
 
@@ -14,8 +14,9 @@ This [post](https://lumigo.io/blog/a-serverless-application-to-clean-up-old-depl
 To guard against deleting live versions, some safeguards are in place:
 
 * **Never delete the $LATEST version**. This is the default version that will be used when you invoke a function.
-* **Never delete versions that are  referenced by an alias**. If you use aliases to manage different stages - dev, staging, etc. then the latest version referenced by your aliases will not be deleted.
-* **Keeping the most recent N versions**. Even if you don't use aliases at all, we will always keep the most recent N versions, where N can be configured with the `VersionsToKeep` parameter when you install the app. **Defaults to 3**.
+* **Never delete versions that are referenced by an alias**. If you use aliases to manage different stages - dev, staging, etc. then the latest version referenced by your aliases will not be deleted.
+* **Never delete layer versions that are referenced by a function alias**. Layer versions referenced by your aliases will not be deleted.
+* **Keeping the most recent N versions**. Even if you don't use aliases at all, we will always keep the most recent N versions, where N can be configured with the `VersionsToKeep` and `LayerVersionsToKeep` parameter when you install the app. **Defaults to 3**.
 
 ## Deploying to your account (via the console)
 
@@ -23,7 +24,7 @@ Go to this [page](https://serverlessrepo.aws.amazon.com/applications/arn:aws:ser
 
 This app would deploy the following resources to your region:
 
-* a Lambda function that scans the functions in your region and deletes unused versions
+* a Lambda function that scans the functions and layers in your region and deletes unused versions
 * a CloudWatch event schedule that triggers the Lambda function every hour
 
 ## Deploying via SAM/Serverless framework/CloudFormation
@@ -39,6 +40,7 @@ AutoDeployMyAwesomeLambdaLayer:
       SemanticVersion: <enter latest version>
     Parameters:
       VersionsToKeep: <defaults to 3>
+      LayerVersionsToKeep: <defaults to 3>
 ```
 
 To do the same via CloudFormation or the Serverless framework, you need to first add the following `Transform`:

--- a/functions/clean.test.js
+++ b/functions/clean.test.js
@@ -14,22 +14,70 @@ Lambda.listAliasedVersions = mockListAliasedVersions;
 const mockDeleteVersion = jest.fn();
 Lambda.deleteVersion = mockDeleteVersion;
 
+const mockListLayers = jest.fn();
+Lambda.listLayers = mockListLayers;
+
+const mockListLayerVersions = jest.fn();
+Lambda.listLayerVersions = mockListLayerVersions;
+
+const mockListLayerVersionsByFunction = jest.fn();
+Lambda.listLayerVersionsByFunction = mockListLayerVersionsByFunction;
+
+const mockDeleteLayerVersion = jest.fn();
+Lambda.deleteLayerVersion = mockDeleteLayerVersion;
+
 afterEach(() => {
 	mockListFunctions.mockClear();
 	mockListVersions.mockClear();
 	mockListAliasedVersions.mockClear();
 	mockDeleteVersion.mockClear();
+	mockListLayers.mockClear();
+	mockListLayerVersions.mockClear();
+	mockListLayerVersionsByFunction.mockClear();
+	mockDeleteLayerVersion.mockClear();
 });
 
-const requireHandler = (versionsToKeep) => {
+const requireHandler = (versionsToKeep, layerVersionsToKeep) => {
 	process.env.VERSIONS_TO_KEEP = versionsToKeep.toString();
+	process.env.LAYER_VERSIONS_TO_KEEP = layerVersionsToKeep.toString();
 	return require("./clean").handler;
 };
 
-test("when there are no functions, it does nothing", async () => {
+test("when there are no functions or layers, it does nothing", async () => {
 	mockListFunctions.mockResolvedValueOnce([]);
+	mockListFunctions.mockResolvedValueOnce([]);
+	mockListLayers.mockResolvedValueOnce([]);
 
-	const handler = requireHandler(0);
+	const handler = requireHandler(0, 0);
+	await handler();
+
+	expect(mockListVersions).not.toBeCalled();
+	expect(mockListAliasedVersions).not.toBeCalled();
+	expect(mockDeleteVersion).not.toBeCalled();
+	expect(mockListLayerVersions).not.toBeCalled();
+	expect(mockDeleteLayerVersion).not.toBeCalled();
+});
+
+test("when there are functions but no layers, it runs ok", async () => {
+	mockListFunctions.mockResolvedValueOnce(["a"]);
+	mockListFunctions.mockResolvedValueOnce(["a"]);
+	mockListLayerVersionsByFunction.mockResolvedValueOnce([]);
+	mockListLayers.mockResolvedValueOnce([]);
+
+	const handler = requireHandler(0, 0);
+	await handler();
+
+	expect(mockListLayerVersions).not.toBeCalled();
+	expect(mockDeleteLayerVersion).not.toBeCalled();
+});
+
+test("when there are layers but no functions, it runs ok", async () => {
+	mockListFunctions.mockResolvedValueOnce([]);
+	mockListFunctions.mockResolvedValueOnce([]);
+	mockListLayerVersionsByFunction.mockResolvedValueOnce(["some-layer:1"]);
+	mockListLayers.mockResolvedValueOnce(["some-layer"]);
+
+	const handler = requireHandler(0, 0);
 	await handler();
 
 	expect(mockListVersions).not.toBeCalled();
@@ -39,10 +87,12 @@ test("when there are no functions, it does nothing", async () => {
 
 test("all unaliased versions of a function is deleted", async () => {
 	mockListFunctions.mockResolvedValueOnce(["a"]);
+	mockListFunctions.mockResolvedValueOnce(["a"]);
 	mockListVersions.mockResolvedValueOnce(["1", "2", "3"]);
 	mockListAliasedVersions.mockResolvedValueOnce(["2"]);
+	mockListLayers.mockResolvedValueOnce([]);
 
-	const handler = requireHandler(0);
+	const handler = requireHandler(0, 0);
 	await handler();
 
 	expect(mockDeleteVersion).toHaveBeenCalledTimes(2);
@@ -50,16 +100,40 @@ test("all unaliased versions of a function is deleted", async () => {
 	expect(mockDeleteVersion).toBeCalledWith("a", "3");
 });
 
+test("all unreferenced versions of a layer is deleted", async () => {
+	mockListFunctions.mockResolvedValueOnce(["a"]);
+	mockListFunctions.mockResolvedValueOnce(["a"]);
+	mockListVersions.mockResolvedValueOnce(["1", "2", "3"]);
+	mockListAliasedVersions.mockResolvedValueOnce(["2", "3"]);
+	mockListLayerVersionsByFunction.mockResolvedValueOnce(["some-layer:1", "other-layer:1"]);
+	mockListLayers.mockResolvedValueOnce(["some-layer", "other-layer"]);
+	mockListLayerVersions.mockResolvedValueOnce(["some-layer:1", "some-layer:2"]);
+	mockListLayerVersions.mockResolvedValueOnce(["other-layer:1", "other-layer:2"]);
+
+	const handler = requireHandler(0, 0);
+	await handler();
+
+	expect(mockDeleteVersion).toHaveBeenCalledTimes(1);
+	expect(mockDeleteVersion).toBeCalledWith("a", "1");
+	expect(mockListVersions).toHaveBeenCalledTimes(1);
+	expect(mockListAliasedVersions).toHaveBeenCalledTimes(1);
+	expect(mockListLayerVersionsByFunction).toHaveBeenCalledTimes(1);
+	expect(mockListLayerVersionsByFunction).toBeCalledWith("a");
+	expect(mockDeleteLayerVersion).toHaveBeenCalledTimes(2);
+	expect(mockDeleteLayerVersion).toBeCalledWith("some-layer", "2");
+	expect(mockDeleteLayerVersion).toBeCalledWith("other-layer", "2");
+});
+
 test("when there are unfinished functions from a previous run, it should carry on", async () => {
 	mockListFunctions.mockResolvedValue(["a", "b"]);
 	mockListVersions.mockResolvedValue(["1"]);
 	mockListAliasedVersions.mockResolvedValue([]);
-	mockDeleteVersion
-		.mockResolvedValueOnce({})
-		.mockRejectedValueOnce(new Error("boom!")); // throw on 'b'
+	mockListLayers.mockResolvedValue([]);
+	mockDeleteVersion.mockResolvedValueOnce({});
+	mockDeleteVersion.mockRejectedValueOnce(new Error("boom!")); // throw on 'b'
 
 	// the first invocation failed on b
-	const handler = requireHandler(0);
+	const handler = requireHandler(0, 0);
 	await expect(handler()).rejects.toThrow("boom!");
 
 	expect(mockDeleteVersion).toBeCalledWith("a", "1");
@@ -72,18 +146,55 @@ test("when there are unfinished functions from a previous run, it should carry o
 	await handler();
 
 	// the retry shouldn't call listFunctions again, and carry on from where it failed last time
-	expect(mockListFunctions).toHaveBeenCalledTimes(1);
+	expect(mockListFunctions).toHaveBeenCalledTimes(2);
 	expect(mockDeleteVersion).toBeCalledWith("b", "1");
+});
+
+test("when there are unfinished layers from a previous run, it should carry on", async () => {
+	mockListFunctions.mockResolvedValue(["a"]);
+	mockListVersions.mockResolvedValue(["1"]);
+	mockListAliasedVersions.mockResolvedValue(["1"]);
+	mockListLayerVersionsByFunction.mockResolvedValueOnce([]);
+	mockListLayers.mockResolvedValueOnce(["a", "b"]);
+	mockListLayerVersions.mockResolvedValueOnce(["a:1"]);
+	mockListLayerVersions.mockResolvedValueOnce(["b:1"]);
+	mockDeleteLayerVersion.mockResolvedValueOnce({});
+	mockDeleteLayerVersion.mockRejectedValueOnce(new Error("boom!")); // throw on 'b:1'
+
+	// the first invocation failed on b
+	const handler = requireHandler(0, 0);
+	await expect(handler()).rejects.toThrow("boom!");
+
+	expect(mockDeleteLayerVersion).toBeCalledWith("a", "1");
+	expect(mockDeleteLayerVersion).toBeCalledWith("b", "1");
+
+	console.log("function is retried...");
+
+	mockDeleteLayerVersion.mockResolvedValueOnce({});
+
+	await handler();
+
+	// the retry shouldn't call listFunctions again, and carry on from where it failed last time
+	expect(mockListLayerVersionsByFunction).toHaveBeenCalledTimes(2);
+	expect(mockDeleteLayerVersion).toBeCalledWith("b", "1");
 });
 
 test("when configured to do so, keep the most recent versions even if they are not aliased", async () => {
 	mockListFunctions.mockResolvedValueOnce(["keep-versions"]);
 	mockListVersions.mockResolvedValueOnce(["1", "2", "3", "4", "5"]);
+	mockListVersions.mockResolvedValueOnce(["1", "2", "3", "4", "5"]);
 	mockListAliasedVersions.mockResolvedValueOnce(["2"]);
+	mockListLayerVersionsByFunction.mockResolvedValue(["a:2", "b:2"]);
+	mockListLayers.mockResolvedValueOnce(["a", "b"]);
+	mockListLayerVersions.mockResolvedValueOnce(["a:1", "a:2", "a:3", "a:4", "a:5"]);
+	mockListLayerVersions.mockResolvedValueOnce(["b:1", "b:2", "b:3", "b:4", "b:5"]);
 
-	const handler = requireHandler(3);
+	const handler = requireHandler(3, 3);
 	await handler();
 
 	expect(mockDeleteVersion).toHaveBeenCalledTimes(1);
 	expect(mockDeleteVersion).toBeCalledWith("keep-versions", "1");
+	expect(mockDeleteLayerVersion).toHaveBeenCalledTimes(2);
+	expect(mockDeleteLayerVersion).toBeCalledWith("a", "1");
+	expect(mockDeleteLayerVersion).toBeCalledWith("b", "1");
 });

--- a/functions/lib/lambda.js
+++ b/functions/lib/lambda.js
@@ -194,7 +194,7 @@ const listAliasedVersions = async (funcArn) => {
 	return loop();
 };
 
-const listLayerVersionsByAlias = async (funcArn) => {
+const listLayerVersionsByFnVersion = async (funcArn) => {
 	log.debug("listing referenced layer versions by alias...", { function: funcArn });
 
 	const params = {
@@ -222,13 +222,17 @@ const listLayerVersionsByAlias = async (funcArn) => {
 const listLayerVersionsByFunction = async (funcArn) => {
 	log.debug("listing referenced layer versions by function...", { function: funcArn });
 
-	const aliasedVersions = await listAliasedVersions(funcArn);
+	let fnVersions = await listVersions(funcArn);
+	fnVersions = fnVersions.concat(["$LATEST"]);
 
 	let layerVersions = [];
 
-	for(let aliasedVersion of aliasedVersions) {
-		const aliasedVersionArn = funcArn + ":" + aliasedVersion;
-		const versions = await listLayerVersionsByAlias(aliasedVersionArn);
+	for(let fnVersion of fnVersions) {
+		let fnVersionArn = funcArn;
+		if( fnVersion !== "$LATEST" ) {
+			fnVersionArn += ":" + fnVersion;
+		}
+		let versions = await listLayerVersionsByFnVersion(fnVersionArn);
 		layerVersions = layerVersions.concat(versions);
 	}
 

--- a/functions/lib/lambda.test.js
+++ b/functions/lib/lambda.test.js
@@ -135,13 +135,11 @@ test("listAliasedVersions gets additional routed versions as well", async () => 
 });
 
 test("listLayerVersionsByFunction gets all layer versions associated with a function", async () => {
-	let offsetFunction = 0;
-	const aliases = n => _.range(0, n).map(() => ({
-		FunctionVersion: (offsetFunction++).toString()
+	const versions = n => _.range(0, n).map(m => ({
+		Version: n < 10 && m === n - 1 ? "$LATEST" : "version"
 	}));
 
-	givenListAliasesReturns(aliases(3));
-
+	givenListVersionsReturns(versions(3));
 
 	let offsetLayer = 0;
 	const layers = n => _.range(0, n).map(() => ({
@@ -224,7 +222,7 @@ describe("error handling", () => {
 	});
 
 	test("should retry getFunctionConfiguration when it errs", async () => {
-		givenListAliasesReturns([{ Alias: "$LATEST" }]);
+		givenListVersionsReturns([{ Version: "$LATEST" }]);
 		givenGetFunctionConfigurationFailsWith("ThrottlingException", "Rate Limited");
 		givenGetFunctionConfigurationReturns([{ Arn: "some-arn:1" }]);
 

--- a/template.yml
+++ b/template.yml
@@ -4,14 +4,14 @@ Transform: AWS::Serverless-2016-10-31
 Metadata:
   AWS::ServerlessRepo::Application:
     Name: lambda-janitor
-    Description: Cron job for deleting old, unused versions of Lambda functions to clean up storage space
+    Description: Cron job for deleting old, unused versions of Lambda functions and layers to clean up storage space
     Author: Lumigo
     SpdxLicenseId: MIT
     LicenseUrl: LICENSE.txt
     ReadmeUrl: README.md
     Labels: ['lambda', 'cron']
     HomePageUrl: https://github.com/lumigo/SAR-Lambda-Janitor
-    SemanticVersion: 1.5.0
+    SemanticVersion: 2.0.0
     SourceCodeUrl: https://github.com/lumigo/SAR-Lambda-Janitor
 
 Resources:
@@ -26,13 +26,17 @@ Resources:
           LOG_LEVEL: INFO
           VERSIONS_TO_KEEP:
             Ref: VersionsToKeep
+          LAYER_VERSIONS_TO_KEEP:
+            Ref: LayerVersionsToKeep
           AWS_NODEJS_CONNECTION_REUSE_ENABLED: 1
       Policies:
         - Statement:
             Effect: Allow
             Action:
               - lambda:DeleteFunction
+              - lambda:DeleteLayerVersion
               - lambda:List*
+              - lambda:GetFunctionConfiguration
             Resource: "*"
       Events:
         CleanScheduledEvent:
@@ -49,6 +53,12 @@ Parameters:
   VersionsToKeep:
     Type: Number
     Description: >-
-      How many versions to keep, even if they are not aliased.
+      How many function versions to keep, even if they are not aliased.
     Default: 3
     MinValue: 0 # don't keep anything except $Latest
+  LayerVersionsToKeep:
+    Type: Number
+    Description: >-
+      How many layer versions to keep that are not referenced.
+    Default: 3
+    MinValue: 0 # don't keep anything


### PR DESCRIPTION
Hi,

I was using your serverless app and found it very helpful.

I think that it would be great to also clean up unused layer versions like it does with functions, hope you find this helpful too.

Thanks!