### PR TITLE
New parameter RoleArn for use during CloudFormation compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,4 +47,11 @@ To do the same via CloudFormation or the Serverless framework, you need to first
 Transform: AWS::Serverless-2016-10-31
 ```
 
+then specify a role to be used by our `AWS::Lambda::Function`:
+
+```yml
+    Parameters:
+      RoleArn: "arn:aws:iam::111111111111:role/MyRole"
+```
+
 For more details, read this [post](https://theburningmonk.com/2019/05/how-to-include-serverless-repository-apps-in-serverless-yml/).

--- a/template.yml
+++ b/template.yml
@@ -39,6 +39,7 @@ Resources:
           Type: Schedule
           Properties:
             Schedule: rate(1 hour)
+      Role: !If [ HasRoleArn, !Ref RoleArn, !Ref 'AWS::NoValue']
 
   LogGroup:
     Type: AWS::Logs::LogGroup
@@ -46,9 +47,16 @@ Resources:
       LogGroupName: !Sub /aws/lambda/${Clean}
 
 Parameters:
+  RoleArn:
+    Type: String
+    Description: >-
+      (CloudFormation compatibility) ARN of an IAM role to use as this function's execution role.
   VersionsToKeep:
     Type: Number
     Description: >-
       How many versions to keep, even if they are not aliased.
     Default: 3
     MinValue: 0 # don't keep anything except $Latest
+
+Conditions:
+  HasRoleArn: !Not [!Equals [!Ref RoleArn, ""]]


### PR DESCRIPTION
When following [the instructions](https://github.com/lumigo-io/SAR-Lambda-Janitor#deploying-via-samserverless-frameworkcloudformation) to run SAR-Lambda-Janitor via CloudFormation, CloudFormation throws the following error:
```
Embedded stack arn:aws:cloudformation:REGION:000000000000:stack/SAR-Lambda-Janitor-SARLambdaJanitor-XXXXXXXXXXXX/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee was not successfully created: The following resource(s) failed to create: [CleanRole].
```

According to the [AWS::Serverless::Function documentation](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-function.html#sam-function-role), the Role property "is required in AWS CloudFormation but not in AWS SAM. If a role isn't specified, one is created for you with a logical ID of \<function-logical-id\>Role."

This change adds a new optional parameter RoleArn that can be used to provide the arn of an existing role when using via CloudFormation.

Syntax checked only; it has not been checked in execution.

