### PR TITLE
Issue 56: add noop mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@ Cron job for deleting old, unused versions of your Function.
 
 This [post](https://lumigo.io/blog/a-serverless-application-to-clean-up-old-deployment-packages/) explains the problem and why we created this app.
 
+## No-Op (no operation, or, dry run) mode
+
+To do dry runs of this app, the environment variable NOOP can be set using the 
+`NoOp` parameter. NoOp will be considered `true` (no active run) if `NoOp` is:
+  * a string that is in the array `["true", "t", "yes", "y"]` when lower-cased
+  * a string that casts to an int >= 1
+
 ## Safeguards
 
 To guard against deleting live versions, some safeguards are in place:
@@ -39,6 +46,7 @@ AutoDeployMyAwesomeLambdaLayer:
       SemanticVersion: <enter latest version>
     Parameters:
       VersionsToKeep: <defaults to 3>
+      NoOp: <optional, defaults to "", i.e. False (do active run)>
 ```
 
 To do the same via CloudFormation or the Serverless framework, you need to first add the following `Transform`:

--- a/functions/lib/lambda.js
+++ b/functions/lib/lambda.js
@@ -139,10 +139,13 @@ const deleteVersion = async (funcArn, version) => {
 	};
 
 	await retry(
-		(bail) => lambda
-			.deleteFunction(params)
-			.promise()
-			.catch(bailIfErrorNotRetryable(bail)),
+		(bail) => {
+			lambda
+				.deleteFunction(params)
+				.promise()
+				.catch(bailIfErrorNotRetryable(bail));
+			log.info("deleted Lambda function version", {function: funcArn,});
+		},
 		getRetryConfig((err) => {
 			log.warn("retrying deleteFunction after error...", { function: funcArn, version }, err);
 		}));

--- a/functions/lib/lambda.js
+++ b/functions/lib/lambda.js
@@ -140,11 +140,12 @@ const deleteVersion = async (funcArn, version) => {
 
 	await retry(
 		(bail) => {
-			lambda
+			const res = lambda
 				.deleteFunction(params)
 				.promise()
 				.catch(bailIfErrorNotRetryable(bail));
 			log.info("deleted Lambda function version", {function: funcArn,});
+			return res;
 		},
 		getRetryConfig((err) => {
 			log.warn("retrying deleteFunction after error...", { function: funcArn, version }, err);

--- a/template.yml
+++ b/template.yml
@@ -26,6 +26,8 @@ Resources:
           LOG_LEVEL: INFO
           VERSIONS_TO_KEEP:
             Ref: VersionsToKeep
+          NOOP:
+            Ref: NoOp
           AWS_NODEJS_CONNECTION_REUSE_ENABLED: 1
       Policies:
         - Statement:
@@ -52,3 +54,7 @@ Parameters:
       How many versions to keep, even if they are not aliased.
     Default: 3
     MinValue: 0 # don't keep anything except $Latest
+  NoOp:
+    Type: String
+    Description: Set to `TRUE`, `YES`, or `1` to perform no-operation runs
+    Default: ""


### PR DESCRIPTION
This PR adds a check for a `NOOP` env variable which may be used to print what _would_ have been done rather than taking active action.

This resolves #56 , which I just created today